### PR TITLE
Use http:// instead of git:// for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "m4"]
 	path = m4
-	url = git://github.com/OpenNMS/autotools.git
+	url = http://github.com/OpenNMS/autotools.git


### PR DESCRIPTION
Git over HTTP is equivalent on eficiency but works across http proxies.

